### PR TITLE
TTBar analysis branch

### DIFF
--- a/include/TTbarAnalysis.hh
+++ b/include/TTbarAnalysis.hh
@@ -61,7 +61,6 @@ namespace QQbarProcessor
 					std::string _JetsColName ,
 					std::string _JetsRelColName ,
 					std::string _JetsVtxColName ,
-					std::string _IsoLeptonColName,
 					std::string _MCVtxColName ,
 					std::string _colRelName
 					);

--- a/src/QQbarProcessor.cc
+++ b/src/QQbarProcessor.cc
@@ -49,15 +49,19 @@ namespace QQbarProcessor
 			     "Name of the Jet collection"  ,
 			     _JetsColName ,
 			     std::string("FinalJets")
-			     //std::string("RecoveredJets")
 			     );
     registerInputCollection( LCIO::LCRELATION,
 			     "JetRelCollectionName" , 
 			     "Name of the PrimaryVertex collection"  ,
 			     _JetsRelColName ,
 			     std::string("FinalJets_rel")
-			     //std::string("RecoveredJets_rel")
 			     );
+		registerInputCollection( LCIO::VERTEX,
+			"GenVtxCollectionName" , 
+			"Name of the PrimaryVertex collection"  ,
+			_MCVtxColName ,
+			std::string("MCVertex")
+		);
     registerInputCollection( LCIO::MCPARTICLE,
 			     "MCCollectionName" , 
 			     "Name of the MC collection"  ,

--- a/src/QQbarProcessor.cc
+++ b/src/QQbarProcessor.cc
@@ -151,7 +151,6 @@ namespace QQbarProcessor
 					    _JetsColName ,
 					    _JetsRelColName ,
 					    _JetsVtxColName ,
-					    _IsoLeptonColName,
 					    _MCVtxColName ,
 					    _colRelName);
        	break;

--- a/src/TTbarAnalysis.cc
+++ b/src/TTbarAnalysis.cc
@@ -33,7 +33,7 @@ namespace QQbarProcessor
 
     
     if(type==0) writer.InitializeStatsTree(_hTree, _stats);
-    else if(type==2) writer.InitializeStatsHadronicTree(_hTree, _stats);
+    else if(type==1) writer.InitializeStatsHadronicTree(_hTree, _stats);
     
     _massCutparameter=masscut;
 

--- a/src/TTbarAnalysis.cc
+++ b/src/TTbarAnalysis.cc
@@ -817,7 +817,6 @@ namespace QQbarProcessor
 						 std::string _JetsColName ,
 						 std::string _JetsRelColName ,
 						 std::string _JetsVtxColName ,
-						 std::string _IsoLeptonColName,
 						 std::string _MCVtxColName ,
 						 std::string _colRelName
 						 )


### PR DESCRIPTION
Minor bug fixes include:
-  Addition of ```registerInputCollection``` for ```MCVertexColName```.
-  From Hadronic process, ```IsoLeptonColName``` was removed since there's no lepton in this process.
-  Analysis type number fix. 0 = Semi-leptonic, 1 = Full-hadronic.

This is a bench marking PR since it works fine now in lx3.

